### PR TITLE
Uint64BE(buffer, offset) signature

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -288,7 +288,7 @@ Reader.prototype.getUInt = function(){
  * @returns {Number} Current int64
  */
 Reader.prototype.getInt64 = function(){
-    var i = Int64(this.buffer.slice(this.pos, this.pos+8)).toNumber();
+    var i = Int64(this.buffer, this.pos).toNumber();
     this.pos += 8;
     return i;
 };
@@ -297,7 +297,7 @@ Reader.prototype.getInt64 = function(){
  * @returns {Number} Current uint64
  */
 Reader.prototype.getUInt64 = function(){
-    var i = UInt64(this.buffer.slice(this.pos, this.pos+8)).toNumber();
+    var i = UInt64(this.buffer, this.pos).toNumber();
     this.pos += 8;
     return i;
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "int64-buffer": "^0.1.1"
+    "int64-buffer": "^0.1.4"
   }
 }


### PR DESCRIPTION
[int64-buffer](https://www.npmjs.com/package/int64-buffer) accepts the constructor arguments of `Uint64BE(buffer, offser)` which makes less memory copy compared to using `this.buffer.slice()`.
