### PR TITLE
Optimize some functions that were taking a long time. Buffer.concat basically turned handleData into a  quadratic function. Node has toggleEndianness (swap16)  builtin nowadays, but I'm not sure if browserify does.

### DIFF
--- a/lib/qtdatastream.js
+++ b/lib/qtdatastream.js
@@ -50,16 +50,8 @@ exports.QTDATASTREAMCLASS = "__QTDATASTREAMCLASS__";
 exports.userTypes = {};
 
 exports.toggleEndianness = function(buffer) {
-    var l = buffer.length;
-    if (l & 0x01) {
-        throw new Error('Buffer length must be even');
-    }
-    var output = new Buffer(l);
-    for (var i = 0; i < l; i += 2) {
-        output[i + 1] = buffer[i];
-        output[i] = buffer[i + 1];
-    }
-    return output; 
+    buffer.swap16();
+    return buffer;
 };
 
 /**
@@ -75,7 +67,7 @@ exports.Socket = function Socket(socket, readCallback, writeCallback) {
     }
     var self = this;
     self.socket = socket;
-    self.oldbuf = null;
+    self.data_state = null;
     self.readCallback = readCallback;
     self.writeCallback = writeCallback;
     
@@ -131,36 +123,67 @@ exports.Socket.prototype.updateSocket = function(socket) {
         }
     });
 
+    function getsize(bufferlist) {
+        // get 4 bytes
+        var final_buffer;
+        if (bufferlist[0] && bufferlist[0].length >= 4) {
+            final_buffer = bufferlist[0];
+        } else {
+            var totallength = 0, i = 0;
+            while(totallength < 4 && i < bufferlist.length) {
+                totallength += bufferlist[i++].length;
+            }
+            if (totallength < 4) return Infinity;
+            final_buffer = Buffer.concat(bufferlist.slice(0,i), totallength);
+        }
+        var reader = new Reader(final_buffer);
+        return reader.size;
+    }
+
     function handleData(err, data) {
         var dataLength;
         if (!err) {
             var stop = false;
             while (!stop) {
-                if (data === null) {
-                    data = self.oldbuf;
-                }else if (self.oldbuf !== null) {
-                    data = Buffer.concat([self.oldbuf, data]);
+                if (!self.data_state) {
+                    self.data_state = {size: Infinity, data: [], recvd: 0};
                 }
-                var reader = new Reader(data);
-                dataLength = data.length - 4;
-                self.emit('progress', dataLength, reader.size);
-                if (reader.size > dataLength) {
+                var ds = self.data_state;
+                if (data !== null) {
+                    ds.data.push(data)
+                    ds.recvd += data.length;
+                }
+                if (ds.size == Infinity && ds.recvd >= 4) {
+                    ds.size = getsize(ds.data);
+                }
+                //dataLength = data.length - 4;
+                self.emit('progress', ds.recvd, ds.size);
+                if (ds.size > ds.recvd) {
                     if (debug) {
-                        logger("("+ dataLength +"/"+ reader.size + ") Waiting for end of buffer");
+                        logger("("+ ds.recvd +"/"+ ds.size + ") Waiting for end of buffer");
                     }
                     stop = true;
-                    self.oldbuf = data;
                 } else {
+                    reader = new Reader(Buffer.concat(ds.data, ds.recvd));
                     if (debug) {
-                        logger("("+ dataLength +"/"+ reader.size + ") Received full buffer");
+                        logger("("+ ds.recvd +"/"+ ds.size + ") Received full buffer");
                     }
                     reader.parse();
                     if (debug) {
                         logger('Received result');
                         logger(reader.parsed);
                     }
-                    self.oldbuf = reader.remaining;
-                    stop = !(self.oldbuf !== null && self.oldbuf.length > 0);
+                    if (reader.remaining && reader.remaining.length > 0) {
+                        self.data_state = {
+                            data: [reader.remaining],
+                            recvd: reader.remaining.length,
+                            size: Infinity
+                        }
+                        stop = false;
+                    } else {
+                        self.data_state = null;
+                        stop = true;
+                    }
                     self.emit('data', reader.parsed);
                 }
                 if (!stop) {

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -190,7 +190,7 @@ Reader.prototype.getString = function(){
     if (stringSize === 0 || stringSize === 0xffffffff) return "";
     
     var stringBuffer = this.buffer.slice(this.pos, this.pos+stringSize);
-    var resultingString = Reader.conv(stringBuffer).toString();
+    var resultingString = Reader.conv(stringBuffer);
     this.pos += stringSize;
     return resultingString;
 };
@@ -200,7 +200,7 @@ Reader.prototype.getString = function(){
  */
 Reader.prototype.getChar = function(){
     var charBuffer = this.buffer.slice(this.pos, this.pos+2);
-    var resultingChar = Reader.conv(charBuffer).toString();
+    var resultingChar = Reader.conv(charBuffer);
     this.pos += 2;
     return resultingChar;
 };
@@ -220,11 +220,10 @@ Reader.prototype.getByteArray = function(){
  * @returns {Array} Current list
  */
 Reader.prototype.getList = function(){
-    var listSize = this.getUInt(), i, list = [], val;
+    var listSize = this.getUInt(), i, list = Array(listSize), val;
     for (i=0; i<listSize; i++) {
         // get value
-        val = this.getQVariant();
-        list.push(val);
+        list[i] = this.getQVariant();
     }
     return list;
 };
@@ -233,11 +232,10 @@ Reader.prototype.getList = function(){
  * @returns {Array<string>} Current list of string
  */
 Reader.prototype.getStringList = function(){
-    var listSize = this.getUInt(), i, list = [], val;
+    var listSize = this.getUInt(), i, list = Array(listSize), val;
     for (i=0; i<listSize; i++) {
         // get value
-        val = this.getString();
-        list.push(val);
+        list[i] = this.getString();
     }
     return list;
 };


### PR DESCRIPTION
Pre-allocate the arrays where possible. readMap still 
shows quite a bit of time, but I think that's because the 
maps are big.