### PR TITLE
Fix off-by-4 error in handleData

### DIFF
--- a/lib/qtdatastream.js
+++ b/lib/qtdatastream.js
@@ -157,15 +157,15 @@ exports.Socket.prototype.updateSocket = function(socket) {
                     ds.size = getsize(ds.data);
                 }
                 self.emit('progress', ds.recvd, ds.size);
-                if (ds.size > ds.recvd) {
+                if (ds.size + 4 > ds.recvd) {
                     if (debug) {
-                        logger("(%d/%d) Waiting for end of buffer", ds.recvd, ds.size);
+                        logger("(%d/%d) Waiting for end of buffer", ds.recvd, ds.size + 4);
                     }
                     stop = true;
                 } else {
                     reader = new Reader(Buffer.concat(ds.data, ds.recvd));
                     if (debug) {
-                        logger("(%d/%d) Received full buffer", ds.recvd, ds.size);
+                        logger("(%d/%d) Received full buffer", ds.recvd, ds.size + 4);
                     }
                     reader.parse();
                     if (debug) {


### PR DESCRIPTION
I forgot to add 4 bytes the packet size to see if the full packet arrived, so the reading could end up mis-aligned and stuck.