### PR TITLE
fix type error when calling toBuffer on a QMap instance constructed with an undefined obj argument

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -792,7 +792,7 @@ class QMap extends QClass {
         bufs.push(QVariant.from(value).toBuffer());
       }
     } else {
-      const keys = Object.keys(this.__obj);
+      const keys = this.__obj ? Object.keys(this.__obj) : [];
       // Map number of elements
       bufs.push(QUInt.from(keys.length).toBuffer());
       for (let key of keys) {


### PR DESCRIPTION
closes #13
